### PR TITLE
fix(ci): repair Dependabot PR automation (claude review + auto-merge)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Allow Dependabot PRs to be reviewed. Without this, claude-code-action
+          # aborts with: "Workflow initiated by non-human actor: dependabot
+          # (type: Bot)". Note: update-version.yml commits to PR branches as
+          # github-actions[bot], but those pushes use the default GITHUB_TOKEN
+          # which does not trigger new workflow runs, so only `dependabot` is
+          # needed here. Add `github-actions` (or use `*`) if that ever changes.
+          allowed_bots: 'dependabot'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,8 +2,10 @@ name: Dependabot Auto-Merge
 
 # NOTE: Using pull_request_target instead of pull_request is intentional.
 # This allows the workflow to run with the repository's full permissions,
-# which is necessary for auto-merge operations. However, this means we MUST
-# verify the PR source is trustworthy (only dependabot[bot]) before taking actions.
+# which is necessary for auto-merge operations. Because pull_request_target fires
+# for ANY PR, every job below is gated with:
+#   if: github.event.pull_request.user.login == 'dependabot[bot]'
+# so non-dependabot PRs skip the whole workflow (no approval, no merge).
 # See: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-run-with-read-only-permissions/
 
 on:
@@ -22,6 +24,10 @@ jobs:
   # Job 1: Auto-Approve the Dependabot PR
   auto-approve:
     name: Auto-Approve Dependabot PR
+    # Dependabot-only gate (see workflow header). This also replaces the old
+    # in-step author check, which exited 0 for non-dependabot PRs and let the
+    # downstream wait-for-tests/auto-merge jobs run anyway.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -34,24 +40,7 @@ jobs:
       GH_REPO: ${{ github.repository }}
 
     steps:
-      - name: Verify PR is from dependabot
-        id: check-dependabot
-        run: |
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-
-          # Check if PR is from dependabot
-          if [[ "$PR_AUTHOR" != "dependabot[bot]" ]]; then
-            echo "✗ PR is from $PR_AUTHOR, not dependabot - skipping"
-            echo "approved=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          echo "✓ PR is from dependabot[bot]"
-          echo "approved=true" >> $GITHUB_OUTPUT
-        shell: bash
-
       - name: Approve PR with GitHub CLI
-        if: steps.check-dependabot.outputs.approved == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -62,13 +51,13 @@ jobs:
         shell: bash
 
       - name: Add approval summary
-        if: steps.check-dependabot.outputs.approved == 'true'
         run: echo "✅ PR Auto-Approved" >> $GITHUB_STEP_SUMMARY
 
   # Job 2: Wait for CI checks to pass
   wait-for-tests:
     name: Wait for CI Tests
     needs: auto-approve
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       checks: read
@@ -84,7 +73,7 @@ jobs:
           echo "Waiting for checks on commit: $SHA"
         shell: bash
 
-      - name: Wait for build workflow to complete
+      - name: Wait for required workflows to complete
         id: wait-workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -93,72 +82,85 @@ jobs:
         run: |
           set -e
 
-          # The actual workflow name from build.yml line 1
-          WORKFLOW_NAME="Build and Publish"
-          MAX_ATTEMPTS=60  # 30 minutes with 30-second intervals
-          ATTEMPT=0
-          WORKFLOW_COMPLETED=false
-          WORKFLOW_PASSED=false
+          # Workflows that must ALL complete successfully before auto-merging:
+          # - "Build and Publish"  : build.yml — build, 6 integration tests, Trivy scan
+          # - "Claude Code Review" : claude-code-review.yml — AI review (gates merge)
+          REQUIRED_WORKFLOWS=("Build and Publish" "Claude Code Review")
 
-          echo "Polling for workflow completion (looking for: $WORKFLOW_NAME)..."
+          MAX_ATTEMPTS=60   # 30 minutes at 30-second intervals
+          INTERVAL=30
+          ATTEMPT=0
+          ALL_DONE=false
+          ALL_PASSED=false
+
+          echo "Waiting for required workflows on commit $COMMIT_SHA:"
+          printf '  - %s\n' "${REQUIRED_WORKFLOWS[@]}"
 
           while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
-            # Get workflow runs for this commit
-            # Use a more defensive approach to handle API failures
-            WORKFLOW_RUNS="{}"
-            if API_RESULT=$(gh api \
-              -H "Accept: application/vnd.github.v3+json" \
-              "repos/$REPO/actions/runs" \
-              -f "head_sha=$COMMIT_SHA" \
-              --jq "[.workflow_runs[] | select(.name == \"$WORKFLOW_NAME\")] | .[0] // {}" 2>&1); then
-              # Only use the result if it's valid JSON
-              if echo "$API_RESULT" | jq -e . >/dev/null 2>&1; then
-                WORKFLOW_RUNS="$API_RESULT"
-              else
-                echo "API returned invalid JSON, using empty object"
-              fi
-            else
-              echo "API call failed, will retry..."
-            fi
-
-            # Check if we found a workflow run
-            WORKFLOW_ID=$(echo "$WORKFLOW_RUNS" | jq -r '.id // empty' 2>/dev/null || echo "")
-
-            if [[ -n "$WORKFLOW_ID" && "$WORKFLOW_ID" != "null" ]]; then
-              STATUS=$(echo "$WORKFLOW_RUNS" | jq -r '.status')
-              CONCLUSION=$(echo "$WORKFLOW_RUNS" | jq -r '.conclusion')
-
-              echo "Workflow Run ID: $WORKFLOW_ID"
-              echo "Status: $STATUS"
-              echo "Conclusion: $CONCLUSION"
-
-              if [[ "$STATUS" == "completed" ]]; then
-                WORKFLOW_COMPLETED=true
-                if [[ "$CONCLUSION" == "success" ]]; then
-                  WORKFLOW_PASSED=true
-                  echo "✓ Workflow completed successfully"
-                else
-                  echo "✗ Workflow failed with conclusion: $CONCLUSION"
-                fi
-                break
-              fi
-            fi
-
             ATTEMPT=$((ATTEMPT + 1))
-            REMAINING_MINUTES=$(((MAX_ATTEMPTS - ATTEMPT) * 30 / 60))
-            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS (${REMAINING_MINUTES}m remaining)... workflow not completed yet, waiting 30s"
-            sleep 30
+
+            # Fetch all workflow runs for this commit in one call.
+            # IMPORTANT: --method GET is required. Passing -f fields without
+            # --method makes gh api default to POST, and POST /actions/runs
+            # does not exist (HTTP 404) — which is why this step used to spin
+            # on "API call failed" forever. head_sha goes in the query string
+            # to avoid -f entirely.
+            ERRFILE=$(mktemp)
+            if ! RAW=$(gh api --method GET \
+                -H "Accept: application/vnd.github.v3+json" \
+                "repos/$REPO/actions/runs?head_sha=$COMMIT_SHA&per_page=100" 2>"$ERRFILE"); then
+              # Print the real error (includes the HTTP status, e.g.
+              # "gh: Not Found (HTTP 404)") instead of a bare "API call failed".
+              echo "✗ gh api failed on attempt $ATTEMPT/$MAX_ATTEMPTS:"
+              sed 's/^/    /' "$ERRFILE"
+              rm -f "$ERRFILE"
+              sleep "$INTERVAL"
+              continue
+            fi
+            rm -f "$ERRFILE"
+
+            ALL_DONE=true
+            ALL_PASSED=true
+            for WF in "${REQUIRED_WORKFLOWS[@]}"; do
+              # Latest run for this workflow name (runs are returned newest-first).
+              RUN_INFO=$(printf '%s' "$RAW" | jq -r \
+                --arg name "$WF" \
+                '[.workflow_runs[] | select(.name == $name)] | .[0] // {}')
+
+              STATUS=$(printf '%s' "$RUN_INFO" | jq -r '.status // "missing"')
+              CONCLUSION=$(printf '%s' "$RUN_INFO" | jq -r '.conclusion // "none"')
+
+              echo "  [$WF] status=$STATUS conclusion=$CONCLUSION"
+
+              if [[ "$STATUS" == "missing" ]]; then
+                ALL_DONE=false      # workflow hasn't started yet
+              elif [[ "$STATUS" != "completed" ]]; then
+                ALL_DONE=false      # still running
+              elif [[ "$CONCLUSION" != "success" ]]; then
+                ALL_PASSED=false    # completed but failed
+              fi
+            done
+
+            if [[ "$ALL_DONE" == true ]]; then
+              break
+            fi
+
+            REMAINING_MINUTES=$(( (MAX_ATTEMPTS - ATTEMPT) * INTERVAL / 60 ))
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS (~${REMAINING_MINUTES}m remaining)... waiting ${INTERVAL}s"
+            sleep "$INTERVAL"
           done
 
-          if [[ $WORKFLOW_COMPLETED == false ]]; then
-            echo "✗ Workflow did not complete within 30 minutes"
+          if [[ "$ALL_DONE" != true ]]; then
+            echo "✗ Required workflows did not complete within $(( MAX_ATTEMPTS * INTERVAL / 60 )) minutes"
             echo "workflow_passed=false" >> $GITHUB_OUTPUT
             exit 1
           fi
 
-          if [[ $WORKFLOW_PASSED == true ]]; then
+          if [[ "$ALL_PASSED" == true ]]; then
+            echo "✓ All required workflows completed successfully"
             echo "workflow_passed=true" >> $GITHUB_OUTPUT
           else
+            echo "✗ One or more required workflows completed with a non-success conclusion"
             echo "workflow_passed=false" >> $GITHUB_OUTPUT
             exit 1
           fi
@@ -228,7 +230,9 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    if: success()
+    # Dependabot-only (see auto-approve). success() preserves the default
+    # "only run if wait-for-tests succeeded" behavior.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && success()
     env:
       # Same as auto-approve: gh pr view/merge/comment need a repo context and
       # there is no checkout step in this job.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,6 +26,12 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+    env:
+      # gh CLI resolves the repo for `gh pr <subcommand> <number>` via either
+      # a git remote, the --repo flag, or GH_REPO. This job has no checkout
+      # step (none is needed to approve), so without GH_REPO gh fails with
+      # "fatal: not a git repository". See wait-for-tests/auto-merge jobs too.
+      GH_REPO: ${{ github.repository }}
 
     steps:
       - name: Verify PR is from dependabot
@@ -223,6 +229,10 @@ jobs:
       pull-requests: write
       contents: write
     if: success()
+    env:
+      # Same as auto-approve: gh pr view/merge/comment need a repo context and
+      # there is no checkout step in this job.
+      GH_REPO: ${{ github.repository }}
 
     steps:
       - name: Check PR is still open

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -109,10 +109,18 @@ jobs:
             if ! RAW=$(gh api --method GET \
                 -H "Accept: application/vnd.github.v3+json" \
                 "repos/$REPO/actions/runs?head_sha=$COMMIT_SHA&per_page=100" 2>"$ERRFILE"); then
-              # Print the real error (includes the HTTP status, e.g.
-              # "gh: Not Found (HTTP 404)") instead of a bare "API call failed".
-              echo "✗ gh api failed on attempt $ATTEMPT/$MAX_ATTEMPTS:"
-              sed 's/^/    /' "$ERRFILE"
+              # Surface the real failure — including the HTTP status code —
+              # instead of a bare "API call failed". gh prints errors to stderr
+              # in the form 'gh: Not Found (HTTP 404)'; extract that code so it
+              # is visible at a glance in the workflow log.
+              HTTP_STATUS=$(grep -oE 'HTTP [0-9]+' "$ERRFILE" | tail -1 || true)
+              if [[ -z "$HTTP_STATUS" ]]; then
+                HTTP_STATUS="HTTP unknown"
+              fi
+              echo "✗ gh api failed on attempt $ATTEMPT/$MAX_ATTEMPTS ($HTTP_STATUS)"
+              echo "    Endpoint: GET repos/$REPO/actions/runs?head_sha=$COMMIT_SHA"
+              echo "    Error output:"
+              sed 's/^/      /' "$ERRFILE"
               rm -f "$ERRFILE"
               sleep "$INTERVAL"
               continue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,15 @@ This is a maintained fork of [sameersbn/docker-apt-cacher-ng](https://github.com
     4. If changed: commits, creates annotated tag, pushes both
     5. Tag format: `v3.7.4-YYYYMMDD` (triggers `build.yml` publish job)
   - Flow on pull requests: validates that script runs without errors
+
+- **.github/workflows/claude-code-review.yml**: AI code review on pull requests
+  - Triggers: `pull_request` opened/synchronize
+  - Uses `anthropics/claude-code-action@v1` with `allowed_bots: 'dependabot'` so Dependabot PRs are reviewed too (without this, the action aborts bot-initiated runs with "non-human actor")
+  - Posts review as a PR comment; is a required workflow for `dependabot-auto-merge.yml` (gates merging)
+
+- **.github/workflows/claude.yml**: Interactive Claude assistant
+  - Triggers: `@claude` mentions in issue/PR comments, and issue open/assign
+  - Uses `anthropics/claude-code-action@v1` with the repo's `CLAUDE.md` for conventions
   - Uses `github-actions[bot]` for automated commits/tags
 
 ### Dependency Management
@@ -84,20 +93,21 @@ This is a maintained fork of [sameersbn/docker-apt-cacher-ng](https://github.com
   - Creates PRs that are automatically tested and merged
 
 - **.github/workflows/dependabot-auto-merge.yml**: Automated Dependabot PR handling
-  - **Auto-Approval**: Automatically approves PRs from dependabot[bot]
-  - **Test Validation**: Waits for "Build and Publish" workflow to complete successfully
-    - Polls every 30 seconds with 30-minute timeout
-    - Validates both GitHub Actions check runs AND traditional commit statuses
-    - Logs failed check runs for debugging
-    - Handles empty/pending workflow states gracefully
-  - **Auto-Merge**: Merges PR automatically after successful tests
+  - **Dependabot-only gating**: Every job has `if: github.event.pull_request.user.login == 'dependabot[bot]'`. Because the workflow uses `pull_request_target` (which fires for any PR), this job-level gate is both a scope control and a security control — non-dependabot PRs skip approval, tests, and merge entirely.
+  - **Auto-Approval**: Approves the Dependabot PR via `gh pr review --approve` (uses `GH_REPO` env var since the job has no checkout step)
+  - **Test Validation**: Waits for required workflows to complete successfully before merging
+    - Required workflows: "Build and Publish" (build.yml) AND "Claude Code Review" (claude-code-review.yml) — the AI review gates the merge
+    - Polls every 30 seconds with 30-minute timeout (single API call per attempt, latest run per workflow)
+    - Uses `gh api --method GET` with `head_sha` in the query string (passing `-f` without `--method` defaults to POST and 404s)
+    - On API failure, prints the real error (including HTTP status) instead of a bare "API call failed"
+    - Also validates GitHub Actions check runs and traditional commit statuses
+  - **Auto-Merge**: Merges PR automatically after successful tests (uses `GH_REPO` env var)
     - Uses merge commit strategy (preserves Dependabot PR history)
     - Enhanced error handling distinguishes between:
       - Expected: auto-merge already enabled (continues)
       - Configuration: repository feature not enabled (fails with helpful message)
       - Blocking: merge conflicts or branch protection violations (fails immediately)
-  - **Security**: Uses pull_request_target with strict verification
-    - Verifies PR author is dependabot[bot] before any action
+  - **Security**: Uses pull_request_target with job-level dependabot[bot] verification
     - Minimal permissions per job (least privilege principle)
     - Documented security implications in workflow comments
   - **Concurrency Control**: Prevents race conditions on the same PR
@@ -123,8 +133,8 @@ This is a maintained fork of [sameersbn/docker-apt-cacher-ng](https://github.com
    - Commits back to PR branch
    ↓
 3. dependabot-auto-merge.yml workflow triggers:
-   - Auto-approves the PR
-   - Waits for build.yml tests to complete (includes version update commit)
+   - Auto-approves the PR (dependabot-only; non-dependabot PRs skip entirely)
+   - Waits for build.yml AND claude-code-review.yml to complete successfully
    - Validates all check runs and statuses
    - Auto-merges if all tests pass
    ↓


### PR DESCRIPTION
## Summary

Dependabot PRs were stuck open (#17–#23) and Claude review was aborting on them. Multiple root causes, all fixed here.

## Changes

### 1. Claude Code Review — `allowed_bots` (`claude-code-review.yml`)
`anthropics/claude-code-action` aborts bot-initiated runs unless allowlisted:
> Workflow initiated by non-human actor: dependabot (type: Bot)

Added `allowed_bots: 'dependabot'`. Only `dependabot` is needed — `update-version.yml` pushes to PR branches via the default `GITHUB_TOKEN`, which doesn't trigger new workflow runs, so `github-actions[bot]` never reaches this workflow.

### 2. `GH_REPO` for `gh` CLI (`dependabot-auto-merge.yml`)
The `auto-approve` and `auto-merge` jobs call `gh pr review/view/merge/comment <number>` with no `actions/checkout` step, so `gh` can't resolve the repo:
> failed to run git: fatal: not a git repository

Set `GH_REPO: ${{ github.repository }}` on both jobs.

### 3. Scope workflow to dependabot only (`dependabot-auto-merge.yml`)
`pull_request_target` fires for **every** PR. The old in-step author check exited `0` for non-dependabot PRs, so `wait-for-tests`/`auto-merge` still ran (security gap + noise on non-dependabot PRs). Added a job-level `if: github.event.pull_request.user.login == 'dependabot[bot]'` to all three jobs and removed the redundant in-step check.

### 4. Wait for Claude Code Review before merging (`dependabot-auto-merge.yml`)
The poller only waited for "Build and Publish"; Claude's review couldn't gate the merge. Now waits for **both** "Build and Publish" and "Claude Code Review" to complete successfully (single API call per attempt, latest run per workflow).

### 5. Fix the polling 404 (`dependabot-auto-merge.yml`)
`gh api ... -f head_sha=...` defaults to **POST**, and `POST /repos/.../actions/runs` doesn't exist (HTTP 404) — so `wait-for-tests` spun on "API call failed" forever and no Dependabot PR ever auto-merged. Switched to `--method GET` with `head_sha` in the query string. Verified live: returns runs correctly.

### 6. Surface the real API error (`dependabot-auto-merge.yml`)
On failure the poller now prints `gh`'s error (including the HTTP status code) instead of a bare "API call failed".

### 7. Docs (`CLAUDE.md`)
Updated the `dependabot-auto-merge.yml` section, release-pipeline diagram, and added `claude-code-review.yml`/`claude.yml` to the workflow list.

## Verification
- [x] Both YAML files parse (`python3 yaml.safe_load`)
- [x] All 13 embedded bash blocks pass `bash -n`
- [x] Live-tested the new polling/jq logic against a real commit SHA — correctly resolves both required workflows with status/conclusion
- [x] Confirmed `--method GET` returns runs (3) while the old `-f` form returns HTTP 404
- [x] Build workflow name "Build and Publish" matches the poller

## After merge
The 7 open Dependabot PRs (#17–#23) won't auto-retrigger (workflow fires on opened/synchronize/reopened). To process them: **Actions → re-run** each failed "Dependabot Auto-Merge" run, or close & reopen each PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>