### PR TITLE
feat(ci): gate auto-approve on Claude review verdict

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      # write so claude-code-action can post a FORMAL review (approve / request
+      # changes) — needed because dependabot-auto-merge now gates on an APPROVED
+      # review. (On Dependabot-triggered runs the GITHUB_TOKEN is read-only by
+      # GitHub policy; the action posts via its OIDC-exchanged app token, which
+      # has write.)
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -48,18 +53,21 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            Review this pull request against the repository's CLAUDE.md conventions.
+            Focus on: code quality, potential bugs, performance, security, and test coverage.
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Post a FORMAL review (not just a comment) using the gh CLI:
+            - If the PR is safe to merge: `gh pr review <number> --approve --body "<summary>"`
+            - If there are blocking issues: `gh pr review <number> --request-changes --body "<issues>"`
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Begin the review body with a verdict line — either `VERDICT: MERGE` or
+            `VERDICT: REQUEST_CHANGES` — followed by your reasoning.
+
+            The dependabot-auto-merge workflow gates merging on an APPROVED review.
+            If you post no review, or post REQUEST_CHANGES, the PR will NOT auto-merge.
+            Be constructive and concise.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,13 +21,143 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Job 1: Auto-Approve the Dependabot PR
+  # Job 1: Wait for Claude Code Review and check its verdict.
+  # Auto-approve (job 2) is gated on Claude posting an APPROVED review, so the
+  # review must complete BEFORE approval. This job polls the Claude Code Review
+  # workflow to completion, then reads the latest formal PR review state.
+  wait-for-review:
+    name: Wait for Claude Review
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: read
+    outputs:
+      review_approved: ${{ steps.check-verdict.outputs.review_approved }}
+    timeout-minutes: 30
+    env:
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Get commit SHA
+        id: get-sha
+        run: |
+          SHA="${{ github.event.pull_request.head.sha }}"
+          echo "commit_sha=$SHA" >> $GITHUB_OUTPUT
+          echo "Waiting for Claude review on commit: $SHA"
+        shell: bash
+
+      - name: Wait for Claude Code Review workflow to complete
+        id: wait-review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ steps.get-sha.outputs.commit_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+
+          WORKFLOW_NAME="Claude Code Review"
+          MAX_ATTEMPTS=60   # 30 minutes at 30-second intervals
+          INTERVAL=30
+          ATTEMPT=0
+          REVIEW_DONE=false
+
+          echo "Polling for workflow completion (looking for: $WORKFLOW_NAME)..."
+
+          while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
+            ATTEMPT=$((ATTEMPT + 1))
+
+            # See wait-for-tests for why --method GET + query string is required
+            # (passing -f head_sha defaults to POST and 404s).
+            ERRFILE=$(mktemp)
+            if ! RAW=$(gh api --method GET \
+                -H "Accept: application/vnd.github.v3+json" \
+                "repos/$REPO/actions/runs?head_sha=$COMMIT_SHA&per_page=100" 2>"$ERRFILE"); then
+              HTTP_STATUS=$(grep -oE 'HTTP [0-9]+' "$ERRFILE" | tail -1 || true)
+              [[ -z "$HTTP_STATUS" ]] && HTTP_STATUS="HTTP unknown"
+              echo "✗ gh api failed on attempt $ATTEMPT/$MAX_ATTEMPTS ($HTTP_STATUS)"
+              echo "    Endpoint: GET repos/$REPO/actions/runs?head_sha=$COMMIT_SHA"
+              echo "    Error output:"
+              sed 's/^/      /' "$ERRFILE"
+              rm -f "$ERRFILE"
+              sleep "$INTERVAL"
+              continue
+            fi
+            rm -f "$ERRFILE"
+
+            RUN_INFO=$(printf '%s' "$RAW" | jq -r \
+              --arg name "$WORKFLOW_NAME" \
+              '[.workflow_runs[] | select(.name == $name)] | .[0] // {}')
+            STATUS=$(printf '%s' "$RUN_INFO" | jq -r '.status // "missing"')
+            CONCLUSION=$(printf '%s' "$RUN_INFO" | jq -r '.conclusion // "none"')
+            echo "  [$WORKFLOW_NAME] status=$STATUS conclusion=$CONCLUSION"
+
+            if [[ "$STATUS" == "completed" ]]; then
+              REVIEW_DONE=true
+              if [[ "$CONCLUSION" != "success" ]]; then
+                echo "⚠ Claude Code Review workflow completed with conclusion: $CONCLUSION"
+              fi
+              break
+            fi
+
+            REMAINING_MINUTES=$(( (MAX_ATTEMPTS - ATTEMPT) * INTERVAL / 60 ))
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS (~${REMAINING_MINUTES}m remaining)... waiting ${INTERVAL}s"
+            sleep "$INTERVAL"
+          done
+
+          if [[ "$REVIEW_DONE" != true ]]; then
+            echo "✗ Claude Code Review did not complete within $(( MAX_ATTEMPTS * INTERVAL / 60 )) minutes"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Check Claude review verdict
+        id: check-verdict
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -e
+
+          # claude-code-action posts a formal PR review: APPROVE (merge) or
+          # REQUEST_CHANGES. Gate auto-approve on APPROVED. If no review was
+          # posted (e.g. the workflow-validation skip on workflow-modifying
+          # PRs, or Claude errored), this fails closed — no approval, no merge.
+          # Retry briefly to allow API propagation right after the run completes.
+          REVIEW_STATE="none"
+          for i in 1 2 3 4 5; do
+            REVIEW_STATE=$(gh pr view "$PR_NUMBER" --json reviews \
+              --jq '.reviews[-1].state // "none"' 2>/dev/null || echo "none")
+            echo "Latest review state: $REVIEW_STATE (attempt $i/5)"
+            [[ "$REVIEW_STATE" == "APPROVED" || "$REVIEW_STATE" == "CHANGES_REQUESTED" ]] && break
+            sleep 5
+          done
+
+          if [[ "$REVIEW_STATE" == "APPROVED" ]]; then
+            echo "✓ Claude approved the PR (verdict: merge)"
+            echo "review_approved=true" >> $GITHUB_OUTPUT
+          else
+            echo "✗ Claude did not approve (latest review state: $REVIEW_STATE). Blocking auto-approve."
+            echo "review_approved=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Report blocked review
+        if: steps.check-verdict.outputs.review_approved != 'true'
+        run: echo "❌ Claude review did not approve — auto-approve skipped" >> $GITHUB_STEP_SUMMARY
+
+      - name: Add review summary
+        if: steps.check-verdict.outputs.review_approved == 'true'
+        run: echo "✅ Claude Review Approved" >> $GITHUB_STEP_SUMMARY
+
+  # Job 2: Auto-Approve — only after Claude's review verdict is "merge".
   auto-approve:
     name: Auto-Approve Dependabot PR
-    # Dependabot-only gate (see workflow header). This also replaces the old
-    # in-step author check, which exited 0 for non-dependabot PRs and let the
-    # downstream wait-for-tests/auto-merge jobs run anyway.
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    needs: wait-for-review
+    # Dependabot-only AND Claude must have posted an APPROVED review. If the
+    # review requested changes (or was skipped/errored), review_approved is
+    # false and this job is skipped → no approval → no merge (fail-closed).
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && needs.wait-for-review.outputs.review_approved == 'true'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -45,15 +175,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "Approving PR #$PR_NUMBER..."
+          echo "Approving PR #$PR_NUMBER (Claude review approved)..."
           gh pr review "$PR_NUMBER" --approve \
-            --body "Auto-approved by dependabot-auto-merge workflow"
+            --body "Auto-approved by dependabot-auto-merge workflow (Claude review verdict: merge)"
         shell: bash
 
       - name: Add approval summary
-        run: echo "✅ PR Auto-Approved" >> $GITHUB_STEP_SUMMARY
+        run: echo "✅ PR Auto-Approved (after Claude review)" >> $GITHUB_STEP_SUMMARY
 
-  # Job 2: Wait for CI checks to pass
+  # Job 3: Wait for build & CI checks to pass (Claude review verdict is
+  # checked in the wait-for-review job above, which gates auto-approve).
   wait-for-tests:
     name: Wait for CI Tests
     needs: auto-approve
@@ -73,7 +204,7 @@ jobs:
           echo "Waiting for checks on commit: $SHA"
         shell: bash
 
-      - name: Wait for required workflows to complete
+      - name: Wait for build workflow to complete
         id: wait-workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,10 +213,11 @@ jobs:
         run: |
           set -e
 
-          # Workflows that must ALL complete successfully before auto-merging:
-          # - "Build and Publish"  : build.yml — build, 6 integration tests, Trivy scan
-          # - "Claude Code Review" : claude-code-review.yml — AI review (gates merge)
-          REQUIRED_WORKFLOWS=("Build and Publish" "Claude Code Review")
+          # The Claude Code Review verdict is checked in the wait-for-review
+          # job (job 1), which gates auto-approve. Here we only wait for the
+          # build/test workflow:
+          # - "Build and Publish" : build.yml — build, 6 integration tests, Trivy scan
+          REQUIRED_WORKFLOWS=("Build and Publish")
 
           MAX_ATTEMPTS=60   # 30 minutes at 30-second intervals
           INTERVAL=30
@@ -230,7 +362,7 @@ jobs:
         if: failure()
         run: echo "❌ CI Tests Failed or Timeout" >> $GITHUB_STEP_SUMMARY
 
-  # Job 3: Auto-merge the PR
+  # Job 4: Auto-merge the PR
   auto-merge:
     name: Auto-Merge PR
     needs: wait-for-tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ This is a maintained fork of [sameersbn/docker-apt-cacher-ng](https://github.com
 - **.github/workflows/claude-code-review.yml**: AI code review on pull requests
   - Triggers: `pull_request` opened/synchronize
   - Uses `anthropics/claude-code-action@v1` with `allowed_bots: 'dependabot'` so Dependabot PRs are reviewed too (without this, the action aborts bot-initiated runs with "non-human actor")
-  - Posts review as a PR comment; is a required workflow for `dependabot-auto-merge.yml` (gates merging)
+  - Posts a FORMAL review (`gh pr review --approve` or `--request-changes`) with a `VERDICT: MERGE` / `VERDICT: REQUEST_CHANGES` line; an APPROVED review gates auto-approve in `dependabot-auto-merge.yml` (no approval → no merge)
 
 - **.github/workflows/claude.yml**: Interactive Claude assistant
   - Triggers: `@claude` mentions in issue/PR comments, and issue open/assign
@@ -94,9 +94,9 @@ This is a maintained fork of [sameersbn/docker-apt-cacher-ng](https://github.com
 
 - **.github/workflows/dependabot-auto-merge.yml**: Automated Dependabot PR handling
   - **Dependabot-only gating**: Every job has `if: github.event.pull_request.user.login == 'dependabot[bot]'`. Because the workflow uses `pull_request_target` (which fires for any PR), this job-level gate is both a scope control and a security control — non-dependabot PRs skip approval, tests, and merge entirely.
-  - **Auto-Approval**: Approves the Dependabot PR via `gh pr review --approve` (uses `GH_REPO` env var since the job has no checkout step)
-  - **Test Validation**: Waits for required workflows to complete successfully before merging
-    - Required workflows: "Build and Publish" (build.yml) AND "Claude Code Review" (claude-code-review.yml) — the AI review gates the merge
+  - **Wait for Review** (job 1, dependabot-only): Polls the "Claude Code Review" workflow to completion on the PR head SHA, then reads the latest formal PR review state. Outputs `review_approved=true` only if Claude posted an APPROVED review; anything else (REQUEST_CHANGES, no review, skipped/errored) blocks the pipeline (fail-closed).
+  - **Auto-Approval** (job 2): Runs only after `wait-for-review` AND only if `review_approved == 'true'`. Approves via `gh pr review --approve` (uses `GH_REPO` env var; no checkout step).
+  - **Test Validation** (job 3): Waits for the "Build and Publish" workflow (build.yml) to complete successfully before merging
     - Polls every 30 seconds with 30-minute timeout (single API call per attempt, latest run per workflow)
     - Uses `gh api --method GET` with `head_sha` in the query string (passing `-f` without `--method` defaults to POST and 404s)
     - On API failure, prints the real error (including HTTP status) instead of a bare "API call failed"
@@ -133,8 +133,9 @@ This is a maintained fork of [sameersbn/docker-apt-cacher-ng](https://github.com
    - Commits back to PR branch
    ↓
 3. dependabot-auto-merge.yml workflow triggers:
-   - Auto-approves the PR (dependabot-only; non-dependabot PRs skip entirely)
-   - Waits for build.yml AND claude-code-review.yml to complete successfully
+   - Waits for claude-code-review.yml to complete and checks its verdict
+   - Auto-approves ONLY if Claude posted an APPROVED review (dependabot-only; non-dependabot PRs skip entirely)
+   - Waits for build.yml to complete successfully
    - Validates all check runs and statuses
    - Auto-merges if all tests pass
    ↓


### PR DESCRIPTION
## Summary

Implements the requested behavior: **auto-approve no longer fires on PR open — it runs only after Claude Code Review posts an APPROVED review.** If Claude posts REQUEST_CHANGES (or no review at all), auto-approve is skipped and the PR does not merge (fail-closed).

> ⚠️ This was originally commit `e22145d` on PR #24, but PR #24 merged at `41f701c` (an earlier commit) before this one landed, so it's stranded. This PR re-applies it cleanly onto current master.

## Changes

### `dependabot-auto-merge.yml` — new job order
1. **wait-for-review** (new, dependabot-only): polls the "Claude Code Review" workflow to completion on the PR head SHA, then reads the latest formal PR review state via `gh pr view --json reviews`. Outputs `review_approved=true` **only** if the latest review is `APPROVED`.
2. **auto-approve**: now `needs: wait-for-review` and runs only if `review_approved == 'true'`.
3. **wait-for-tests**: now waits only for "Build and Publish" (the review verdict is handled in job 1).
4. **auto-merge**: unchanged.

Fail-closed chain: no APPROVED review → auto-approve skipped → wait-for-tests skipped → auto-merge skipped → no merge.

### `claude-code-review.yml`
- **Prompt**: Claude now posts a **formal review** (`gh pr review --approve` / `--request-changes`) with a `VERDICT: MERGE`/`VERDICT: REQUEST_CHANGES` line, instead of a free-form `gh pr comment` (which carried no parseable verdict).
- **allowed_tools**: `gh pr comment` → `gh pr review`.
- **permissions**: `pull-requests: read` → `write` (to post formal reviews; on Dependabot runs the action posts via its OIDC app token, which has write).

### `CLAUDE.md`
Documented the new job order, verdict mechanism, and pipeline diagram.

## Verification
- [x] YAML parses; all bash `run:` blocks pass `bash -n`
- [x] Live-tested the verdict fetch: a PR with no reviews returns `none` → `review_approved=false` (fail-closed)
- [x] Cherry-pick onto master is conflict-free (the 3 files were untouched by PR #22/#23)

## ⚠️ Critical prerequisites (read before merging)

1. **Dependabot secret still missing.** `CLAUDE_CODE_OAUTH_TOKEN` exists as an Actions secret but NOT as a Dependabot secret. On Dependabot-triggered `pull_request` runs, only Dependabot secrets are visible, so Claude review currently fails at auth:
   > Environment variable validation failed: Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity federation is required
   Until you set it (`gh secret set CLAUDE_CODE_OAUTH_TOKEN --app dependabot`), Claude can't review Dependabot PRs → `review_approved` is always false → **no Dependabot PR can auto-merge**. (master is *already* in this state because wait-for-tests requires Claude review to pass.)

2. **No branch protection on master.** The gate lives entirely in the workflow — GitHub enforces no required reviews/checks. Consider adding branch protection (require the "Build and Publish" + "Claude Code Review" checks, require approvals) so the gate can't be bypassed by a manual merge.

3. **Workflow-validation skip:** claude-code-action refuses to run on PRs that modify its own workflow file (security feature) — so this PR's own Claude review will be skipped. That's expected; it only affects workflow-modifying PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>