### PR TITLE
fix(ci): add least-privilege permissions to flagged build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,11 @@ jobs:
       needs: [build-test-image]
       runs-on: ubuntu-latest
 
+      # Least-privilege token for integration tests: only needs to read the
+      # repository contents (checkout). No packages/SARIF writes here.
+      permissions:
+        contents: read
+
       steps:
         - name: Checkout git repo
           uses: actions/checkout@v6
@@ -235,6 +240,12 @@ jobs:
     name: Build and Push Docker Image
     needs: [test-integration]
     runs-on: ubuntu-latest
+
+    # Least-privilege token for publishing: read the repo (checkout) and write
+    # container packages to ghcr.io. Only the GITHUB_TOKEN is used for login.
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Resolves the **2 open CodeQL alerts** in `.github/workflows/build.yml` for rule `actions/missing-workflow-permissions` (#92, #93).

CodeQL flagged the `test-integration` and `build-and-push-docker-image` jobs because they had **no explicit `permissions:` block**, so they inherited the repository/organization default `GITHUB_TOKEN` permissions instead of following least privilege.

## Changes

Added least-privilege `permissions:` blocks to the two flagged jobs, matching the existing per-job style already used by `build-test-image`:

| Job | Permissions | Reason |
|-----|-------------|--------|
| `test-integration` | `contents: read` | Only checks out the repo; no writes or SARIF upload |
| `build-and-push-docker-image` | `contents: read` + `packages: write` | Checks out the repo and pushes images to ghcr.io via `GITHUB_TOKEN` |

The `build-test-image` job already had a proper `permissions:` block and was not flagged.

## Verification

- ✅ YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- ✅ All three jobs now declare explicit `permissions:`
- ✅ Confirmed other workflow files already had `permissions:` blocks — CodeQL correctly only flagged `build.yml`
- ✅ Diff is minimal: 11 insertions, no behavioral change to job logic

## Alerts addressed

- CodeQL #92 — `actions/missing-workflow-permissions` (`test-integration`)
- CodeQL #93 — `actions/missing-workflow-permissions` (`build-and-push-docker-image`)

Once merged to master, the next CodeQL analysis run should auto-close both alerts.